### PR TITLE
Add hamail_volatile_meta_keys() helper + dashboard listing

### DIFF
--- a/app/Hametuha/Hamail/Ui/SettingsScreen.php
+++ b/app/Hametuha/Hamail/Ui/SettingsScreen.php
@@ -165,6 +165,22 @@ class SettingsScreen extends Singleton {
 					<?php submit_button( __( 'Send mail', 'hamail' ) ); ?>
 				</form>
 			<?php endif; ?>
+
+			<hr />
+
+			<h2><?php esc_html_e( 'Volatile Custom Fields', 'hamail' ); ?></h2>
+			<p class="description">
+				<?php
+				printf(
+					// translators: %s is plugin name.
+					wp_kses_post( __( 'These custom fields represent send/schedule state and should not be carried over when a post is duplicated. If you use a plugin like %s, copy the keys below into its "Do not copy these fields" setting.', 'hamail' ) ),
+					'<a href="https://wordpress.org/plugins/duplicate-post/" target="_blank" rel="noopener noreferrer">Yoast Duplicate Post</a>'
+				);
+				?>
+			</p>
+			<p>
+				<code><?php echo esc_html( implode( ', ', hamail_volatile_meta_keys() ) ); ?></code>
+			</p>
 		</div><!-- //.wrap -->
 		<?php
 	}

--- a/functions/duplicate.php
+++ b/functions/duplicate.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Post duplication helpers.
+ *
+ * @package hamail
+ */
+
+defined( 'ABSPATH' ) || die();
+
+/**
+ * Meta keys that represent send/schedule state and should NOT be carried over
+ * when a post is duplicated.
+ *
+ * Use this list when configuring duplication plugins. For example, in
+ * Yoast Duplicate Post: Settings → Permissions → "Do not copy these fields".
+ *
+ * @return string[]
+ */
+function hamail_volatile_meta_keys() {
+	return apply_filters( 'hamail_volatile_meta_keys', [
+		// Transactional mail (hamail).
+		'_hamail_sent',
+		'_hamail_message_ids',
+		'_hamail_log',
+		// Marketing mail (hamail-marketing).
+		'_hamail_sent_at',
+		'_hamail_scheduled_at',
+		'_hamail_marketing_id',
+	] );
+}


### PR DESCRIPTION
## Summary
- Adds `hamail_volatile_meta_keys()` — returns the list of meta keys that represent send/schedule state (e.g. `_hamail_sent`, `_hamail_marketing_id`) and therefore should NOT be carried over when a post is duplicated.
- Filterable via `apply_filters( 'hamail_volatile_meta_keys', ... )`.
- Displays the list on the Hamail dashboard so admins can copy them into Yoast Duplicate Post's "Do not copy these fields" setting.

複製プラグイン（Yoast Duplicate Post 等）への自動連携はあえてしません。Yoast 側に GUI があり、フィルター連携が必要な人は `hamail_volatile_meta_keys()` を使って自前で書けるためです。

Refs #47

## Test plan
- [x] CI passes
- [x] Hamail ダッシュボードの末尾に「Volatile Custom Fields」セクションが出る
- [x] 表示されるキーが期待通り（`_hamail_sent`, `_hamail_message_ids`, `_hamail_log`, `_hamail_sent_at`, `_hamail_scheduled_at`, `_hamail_marketing_id`）
- [x] `apply_filters( 'hamail_volatile_meta_keys', ... )` で追加・削除ができる

🤖 Generated with [Claude Code](https://claude.com/claude-code)