### PR TITLE
Skip deploy workflow for ci-artifacts release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   wp_org:
     name: Deploy WordPress.org
+    # Skip non-version releases (e.g. the `ci-artifacts` release used by
+    # Playground preview uploads). The production environment also enforces
+    # a `*.*.*` tag policy as a second line of defense.
+    if: github.event.release.tag_name != 'ci-artifacts'
     runs-on: ubuntu-latest
     environment:
       name: production


### PR DESCRIPTION
## Summary
Playground プレビュー機能（PR #83）で導入された `ci-artifacts` リリースに、deploy ワークフローが反応してしまう問題を防ぐためのガードを追加。

現状でも `production` environment に `*.*.*` タグポリシーがあるので **実害は出ません** が、deploy ジョブが起動して environment 検証で失敗するため、Playground プレビューを使うたびにActionsタブに赤いログが残ります。

ジョブ条件で `ci-artifacts` を明示除外することで、そもそも起動させない。

## Test plan
- [ ] CI passes
- [ ] このPRをマージしたあと、`ci-artifacts` リリースを publish しても `Deploy Plugin` ワークフローが起動しないこと（skip表示）
- [ ] 通常のリリース (`2.x.y`) では従来通り deploy が走ること（次回リリース時に確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)