### PR TITLE
Fix: anchor `src` in .distignore so vendor src dirs aren't stripped

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -20,7 +20,7 @@ phpstan-baseline.neon
 phpstan-bootstrap.php
 phpunit.xml.dist
 README.md
-src
+/src
 stylelint.config.js
 wordpress
 bin

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Tags: email, sendgrid, marketing  
 Contributors: Takahashi_Fumiki, hametuha  
-Tested up to: 6.8  
+Tested up to: 6.9  
 Stable Tag: nightly  
 License: GPLv3 or later  
 License URI: http://www.gnu.org/licenses/gpl-3.0.txt
@@ -66,6 +66,10 @@ We have [Wiki on GitHub](https://github.com/hametuha/hamail/wiki). Please check 
 We have [GitHub Repository](https://github.com/hametuha/hamail). Issues and Pull Requests are welcomed.
 
 ## Changelog
+
+### 2.8.2
+
+* Bugfix: wrong `.distignore` broke vendor directory.
 
 ### 2.8.1
 


### PR DESCRIPTION
## 概要

2.8.1 で `.distignore` に追加された `src`（アンカー無し）が、`wp dist-archive` 実行時に **vendor 配下の `src/` ディレクトリまで除外**してしまい、リリースzipから以下が欠落していました。

- `vendor/starkbank/ecdsa/src/`（SendGrid Webhook署名検証 / starkbank/ecdsa）
- `vendor/tijsverkoyen/css-to-inline-styles/src/`（メール本文のCSSインライン化）

その結果、Composerオートローダのブートストラップで `starkbank/ecdsa/src/ellipticcurve.php` の require に失敗し、`plugins_loaded` フックで **全リクエストが Fatal error** になりました（本番サイト全停止を確認）。

```
PHP Fatal error: Uncaught Error: Failed opening required
'.../hamail/vendor/composer/../starkbank/ecdsa/src/ellipticcurve.php'
 in .../hamail/vendor/composer/autoload_real.php:41
```

## 修正

`.distignore` のパターンを行頭アンカー付きに変更し、**トップレベルの `src/` のみ**を除外対象にします。

```diff
-src
+/src
```

`.distignore` は `.gitignore` と同様のマッチ規則で、アンカー無しの `src` は全階層の同名ディレクトリにマッチします。`/src` とすることでアーカイブルート直下の `src/`（ビルド前のJS/SCSSソース）だけを除外し、`vendor/**/src` は保持されます。

## 影響を受けた依存（vendor内で `src/` を持つもの）

- `starkbank/ecdsa`
- `tijsverkoyen/css-to-inline-styles`

（`sendgrid/sendgrid` は `lib/` のため影響なし）

## リリースについて

このパッチを含めて 2.8.2 をリリースし直す必要があります。既に 2.8.1 を本番反映済みの環境では、上記2ディレクトリを手動アップロードするか 2.8.2 へ更新することで復旧します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)