### PR TITLE
Fix: .distignore の wordpress を行頭アンカーして vendor 配下の誤除外を防ぐ

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -22,7 +22,7 @@ phpunit.xml.dist
 README.md
 /src
 stylelint.config.js
-wordpress
+/wordpress
 bin
 tests
 hamail.php.bak


### PR DESCRIPTION
## 背景

`wp dist-archive` が読む `.distignore` は `.gitignore` と同じく、行頭スラッシュなしのパターンは全階層に再帰マッチします。`wordpress` と書くと `vendor/**/wordpress` のような配下のディレクトリまで除外され、Composer オートロードが壊れてインストール直後に fatal error になる恐れがあります（2.8.1 で `src` が `vendor/**/src` を巻き込み実際に事故が発生）。

ルート直下のみを除外したいディレクトリは `/wordpress` のように行頭アンカーを付ける必要があります。

## 変更内容

- `.distignore` の `wordpress` → `/wordpress`（行頭アンカーを追加）

`src` は master 上で既に `/src` にアンカー済みのため、本 PR では未対応だった `wordpress` のみを修正します。`.wordpress-org` など別物の行や glob を含む行は変更していません。